### PR TITLE
Set session storage for APP_STATE_STORE

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def create_app():
     app.layout = html.Div(children=[
 
         # Stores and Divs needed for the layout to work properly
-        dcc.Store(id=ID.APP_STATE_STORE.value),
+        dcc.Store(id=ID.APP_STATE_STORE.value, storage_type="session"),
         dcc.Store(id=ID.ANIMATION_STATE_STORE.value),
         dcc.Store(id=ID.HOME_TAB_SELECTED_STATE_STORE, data=None),
         html.Div(id="app-init-trigger", style={"display": "none"}),


### PR DESCRIPTION
Changed the storage type of APP_STATE_STORE to "session" to persist state only for the current session. This ensures a more predictable behavior and prevents undesired state retention across sessions.